### PR TITLE
feat(api): add genre-based anime endpoint and fixed movie

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The repository owner is not responsible for any misuse or illegal activities per
     - [Animes](#anime)
     - [Cartoons](#cartoons)
     - [Networks](#networks)
-    - [Genres](#genres)
+    - [Genres](#genre)
     - [Languages](#languages)
     - [Schedule](#schedule)
     - [Anime Stream Info](#anime-stream-info)

--- a/README.md
+++ b/README.md
@@ -824,3 +824,87 @@ console.log(resp.data);
   }
 }
 ```
+```
+### Genre
+
+```bash
+GET /api/genre
+```
+
+### 🔗 Endpoint
+
+```bash
+/api/genre?id={string}
+```
+#### Example of request
+
+
+```javascript
+import axios from "axios";
+const resp = await axios.get("/api/genre?id=animation");
+console.log(resp.data);
+```
+
+#### Sample response
+
+```javascript
+{
+  "success": true,
+  "results": {
+    "success": true,
+    "currentPage": 1,
+    "results": [
+      {
+        "title": "The Ramparts of Ice",
+        "anime_id": "seriesthe-ramparts-of-ice",
+        "poster": "https://image.tmdb.org/t/p/w500/rke9UC2QrogvxiQD9TGpbvqDosi.jpg"
+      },
+      {
+        "title": "Dr. STONE",
+        "anime_id": "seriesdr-stone",
+        "poster": "https://image.tmdb.org/t/p/w500/x96E9mxxQf5KzXOzIu0ldsfc3QK.jpg"
+      },
+      {
+        "title": "Fairy Tail",
+        "anime_id": "seriesfairy-tail",
+        "poster": "https://image.tmdb.org/t/p/w500/dorzFzD65utfD39pEu7PbcXmEFH.jpg"
+      },
+      {
+        "title": "Dorohedoro",
+        "anime_id": "seriesdorohedoro",
+        "poster": "https://image.tmdb.org/t/p/w500/zSMmRTopPIRr6913KX8pyiV6zsK.jpg"
+      },
+      {
+        "title": "Scarlet",
+        "anime_id": "moviesscarlet",
+        "poster": "https://image.tmdb.org/t/p/w500/2O2tOyS4kvO9GtFPHpWmbXvfRQv.jpg"
+      },
+      {
+        "title": "Fullmetal Alchemist: Brotherhood",
+        "anime_id": "seriesfullmetal-alchemist-brotherhood",
+        "poster": "https://image.tmdb.org/t/p/w500/5ZFUEOULaVml7pQuXxhpR2SmVUw.jpg"
+      },
+      {
+        "title": "Tokyo Ghoul All",
+        "anime_id": "seriestokyo-ghoul-all",
+        "poster": "https://image.tmdb.org/t/p/w500/wCn96kKQBRQhImMorf3napmCjfM.jpg"
+      },
+      {
+        "title": "The Beginning After the End",
+        "anime_id": "seriesthe-beginning-after-the-end",
+        "poster": "https://image.tmdb.org/t/p/w500/d23Lspt2mbVP8WwJNgb5Sg4Kdhu.jpg"
+      },
+      {
+        "title": "Witch Hat Atelier",
+        "anime_id": "serieswitch-hat-atelier",
+        "poster": "https://image.tmdb.org/t/p/w500/78m1Tv3suHmUryTI9VNPwKLKjHZ.jpg"
+      },
+      {
+        "title": "BOFURI: I Don't Want to Get Hurt, so I'll Max Out My Defense.",
+        "anime_id": "seriesbofuri-i-dont-want-to-get-hurt-so-ill-max-out-my-defense",
+        "poster": "https://image.tmdb.org/t/p/w500/2PLjOPstyBIWdQftMLnYRE5Cojg.jpg"
+      }
+    ]
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -824,9 +824,7 @@ console.log(resp.data);
   }
 }
 ```
-```
 ### Genre
-
 ```bash
 GET /api/genre
 ```

--- a/src/controllers/genre.controller.js
+++ b/src/controllers/genre.controller.js
@@ -1,0 +1,25 @@
+const genreScraper = require("../scrapers/genre")
+
+const genreController = async (req, res, next) => {
+  try {
+    const genre = req.query.id
+    const page = req.query.page || 1
+    
+    if (!genre) {
+      res.status(400).json({ success: false, message: "Genre ID is required" })
+      return
+    }
+
+    const results = await genreScraper(genre, page)
+    
+    res.json({
+      success: true,
+      results
+    })
+
+  } catch (err) {
+    next(err)
+  }
+}
+
+module.exports = genreController

--- a/src/controllers/moviesStream.controllers.js
+++ b/src/controllers/moviesStream.controllers.js
@@ -4,24 +4,38 @@ const redis = require("../configs/redis")
 const moviesStreamController = async(req,res,next)=>{
     try{
         const anime_id = req.query.id
-    const catchData = await redis.get(anime_id)
-    if(catchData){
-        res.json({
-            success: true,
-            message: "redis found",
-            results: catchData
+        if (!anime_id) {
+            return res.status(400).json({
+                success: false,
+                message: "id query param is required",
+                results: {}
+            })
+        }
+
+        const cacheKey = `movie-info:${anime_id}`
+        const catchData = await redis.get(cacheKey)
+        if(catchData){
+            const parsedResults = typeof catchData === "string" ? JSON.parse(catchData) : catchData
+            return res.json({
+                success: true,
+                message: "data found",
+                results: parsedResults
+            })
+        }
+
+        const results = await moviesStream(anime_id)
+        
+        if (results) {
+            await redis.set(cacheKey, JSON.stringify(results), {
+                ex: 86400
+            })
+        }
+
+        return res.json({
+            success: results ? true : false,
+            message: results ? "data found" : "data not found",
+            results: results || {}
         })
-    }
-    const results = await moviesStream(anime_id)
-    console.log(results)
-    await redis.set(anime_id,JSON.stringify(results),{
-        ex: 86400
-    })
-    res.json({
-        success: true,
-        message: "data found",
-        results
-    })
     }catch(err){
         next(err)
     }

--- a/src/scrapers/genre.js
+++ b/src/scrapers/genre.js
@@ -1,0 +1,57 @@
+const { default: axios } = require("axios")
+const cheerio = require("cheerio")
+const url = require("../utils/Base_V5.js")
+const Header = require("../configs/headers.js")
+
+const genreScraper = async (genre, page = 1) => {
+    try {
+        // Map special names to correct slugs
+        const genreMap = {
+            "action & adventure": "action-adventure",
+            "sci-fi & fantasy": "sci-fi-fantasy",
+            "martial art": "martial-art",
+            "sci-fi": "sci-fi"
+        };
+        
+        let slug = genre.toLowerCase().trim();
+        if (genreMap[slug]) {
+            slug = genreMap[slug];
+        } else {
+            slug = slug.replace(/\s+/g, '-');
+        }
+
+        const fetchUrl = `${url}/category/${slug}/page/${page}/`
+        console.log("Fetching Genre URL:", fetchUrl);
+        
+        const { data } = await axios.get(fetchUrl, { headers: Header })
+        const $ = await cheerio.load(data)
+        const anime = []
+        
+        // Try multiple selectors
+        const items = $(".movies-list li").length ? $(".movies-list li") : $("#aa-movies li");
+        
+        items.each((_, el) => {
+            const title = $(el).find(".entry-title, h2").text().trim()
+            const anime_id = $(el).find("a").attr("href")?.replace(url, "").replace(/\//g, "")
+            const imgTag = $(el).find("img");
+            let poster = imgTag.attr("data-src") || imgTag.attr("src");
+            
+            if (poster && poster.startsWith("//")) {
+                poster = "https:" + poster;
+            }
+            if (title && anime_id) {
+                anime.push({ title, anime_id, poster })
+            }
+        })
+
+        return {
+            success: true,
+            currentPage: page,
+            results: anime
+        }
+    } catch (err) {
+        console.error("Genre Scraper Error:", err.message);
+        return { success: false, results: [], error: err.message }
+    }
+}
+module.exports = genreScraper

--- a/src/scrapers/streams/helper.js
+++ b/src/scrapers/streams/helper.js
@@ -1,9 +1,27 @@
 const axios = require("axios");
 const cheerio = require("cheerio");
 const url = require("../../utils/Base_V5")
+const header = require("../../configs/headers")
 async function scrapePlayers(anime_id) {
+    const urlsToTry = [
+        `${url}/movies/${anime_id}/`,
+        `${url}/movies/${anime_id}`,
+    ];
+    let data;
+    for (const pageUrl of urlsToTry) {
+        try {
+            const response = await axios.get(pageUrl, {
+                headers: header,
+                timeout: 10000
+            });
+            data = response.data;
+            if (data) break;
+        } catch (e) {
+            continue;
+        }
+    }
 
-    const { data } = await axios.get(`${url}/movies/${anime_id}`);
+    if (!data) return [];
 
     const $ = cheerio.load(data);
 
@@ -24,7 +42,10 @@ async function scrapePlayers(anime_id) {
 
         try {
 
-            const { data } = await axios.get(link);
+            const { data } = await axios.get(link, {
+                headers: header,
+                timeout: 10000
+            });
 
             const $$ = cheerio.load(data);
 

--- a/src/scrapers/streams/movies.js
+++ b/src/scrapers/streams/movies.js
@@ -1,37 +1,73 @@
 const { default: axios } = require("axios");
 const cheerio = require("cheerio")
-const url = require("../../utils/Base_V5")
+const url = require("../../utils/Base_V5.js")
 const header = require("../../configs/headers")
 const helper = require("./helper")
 
 const infiScraper = async (anime_id) => {
     try {
-        const { data } = await axios.get(`${url}/movies/${anime_id}/`, { headers: header })
+        if (!anime_id) return null;
+        const cleanId = anime_id.replace(/\/$/, "");
+        const urlsToTry = [
+            `${url}/movies/${cleanId}/`,
+            `${url}/movies/${cleanId}`,
+            `${url}/${cleanId}/`,
+            `${url}/${cleanId}`
+        ];
+
+        let data, fetchUrl;
+        for (const testUrl of urlsToTry) {
+            try {
+                const response = await axios.get(testUrl, { headers: header, timeout: 10000 });
+                if (response?.data) {
+                    data = response.data;
+                    fetchUrl = testUrl;
+                    break;
+                }
+            } catch (e) {
+                continue;
+            }
+        }
+
+        if (!data) {
+            return null;
+        }
+
         const $ = await cheerio.load(data)
-        const title = $(".fg1 .entry-title").text().trim()
-        const descriptionDiv = $(".description");
+        const title = $(".fg1 .entry-title, .entry-title, h1, .name").first().text().trim()
+            || $('meta[property="og:title"]').attr("content")?.trim()
+        if (!title) return null;
 
-        // First <p> = Story
-        const overview = descriptionDiv.find("p").first().text().trim();
-
-        // Remaining <p> tags
-        const details = descriptionDiv.find("p").slice(1);
+        const descriptionDiv = $(".description, .synopsis, #edit-2");
+        const overview = descriptionDiv.find("p").first().text().trim() || $(".wp-content p").first().text().trim();
 
         const languages = [];
-        $('#menu-item-4819 a').each((i, el) => {
+        $('.language-list a, .language a, .mvic-info p:contains("Language") a').each((i, el) => {
             languages.push($(el).text().trim());
         });
-        const run_time = $(".duration").text().trim()
-        const genres = $(".genres a").map((i, el) => $(el).text().trim()).get();
-        const year = $(".year").text().trim()
-        const seasons = $(".seasons").text().trim().replace("Seasons", "").trim()
-        const episodes = $(".entry-meta .episodes").text().trim().replace("Episodes", "").trim()
-        const rating = $(".vote-cn .vote").text().replace("TMDB", "").trim()
-        const poster = "https:" + $(".dfxb img").attr("src")
-        const stream = await helper(anime_id)
+
+        const run_time = $(".duration, .runtime, .runtime-info").text().trim()
+            || $('.description p:contains("Running time")').text().replace("Running time:", "").trim()
+        const genres = $(".genres a, .genre a").map((i, el) => $(el).text().trim()).get();
+        const year = $(".year, .date").text().trim() || $('meta[property="movie:release_date"]').attr("content")?.slice(0, 4) || ""
+        const rating = $(".vote-cn .vote, .imdb-rating, .rating-info").text().replace(/TMDB|IMDB/g, "").trim()
+        
+        const imgTag = $(".dfxb img, .poster img, .mvic-thumb img");
+        let poster = imgTag.attr("data-src") || imgTag.attr("src") || imgTag.attr("data-lazy-src");
+        if (poster && poster.startsWith("//")) {
+            poster = "https:" + poster;
+        } else if (poster && !poster.startsWith("http")) {
+            poster = url + (poster.startsWith("/") ? "" : "/") + poster;
+        }
+        if (!poster) {
+            poster = $('meta[property="og:image"]').attr("content") || ""
+        }
+
+        const stream = await helper(cleanId)
+        
         const results = {
             title,
-            anime_id,
+            anime_id: cleanId,
             poster,
             overview,
             languages,
@@ -41,11 +77,9 @@ const infiScraper = async (anime_id) => {
             rating,
             stream
         }
-        console.log(results)
         return results
     } catch (err) {
-        console.log(err)
+        return null;
     }
 }
-infiScraper("miraculous-world-shanghai-the-legend-of-ladydragon")
 module.exports = infiScraper


### PR DESCRIPTION
# Added Genre API Endpoint

## Overview

This PR adds a new genre-based endpoint to the API that allows users to fetch anime by genre.

## New Endpoint

`GET /api/genre?id={genre}`

### Example Request

```js
const resp = await axios.get("/api/genre?id=animation");
console.log(resp.data);
```

## Features

* Fetch anime using genre IDs
* Returns paginated results
* Includes title, anime_id, and poster
* Easy integration for frontend category browsing

## Added Files

* `controllers/genre.controller.js`
* `scrapers/genre.js`

## Example Response

```json
{
  "success": true,
  "results": {
    "currentPage": 1,
    "results": [...]
  }
}
```

## Use Case

Useful for anime streaming websites and applications that need genre-based browsing and filtering.
